### PR TITLE
Update extract-frontmatter from v2.1.0 to v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "82f36e03049327b02edc7e8224b54cc20cde398e46e99e3f0cc032ff315e9301"
 
 [[package]]
 name = "extract-frontmatter"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8df79f381ac7f913d37d0353883635e8a2de59bfb991495be2320ae2e15d358"
+checksum = "46ed88b524528147d3055c70746165356731a9a688c5ea3260d39a156e6a03ae"
 
 [[package]]
 name = "getopts"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "82f36e03049327b02edc7e8224b54cc20cde398e46e99e3f0cc032ff315e9301"
 
 [[package]]
 name = "extract-frontmatter"
-version = "2.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b4c6ac125f7d6663c9bee567645050c9a164c4dbf5689bd5bdf344a1b39356"
+checksum = "a8df79f381ac7f913d37d0353883635e8a2de59bfb991495be2320ae2e15d358"
 
 [[package]]
 name = "getopts"
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "sedum"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "epoch-converter",
  "extract-frontmatter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming"]
 
 [dependencies]
 walkdir = "2.3.2"
-extract-frontmatter = "4.0.0"
+extract-frontmatter = "4.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 pulldown-cmark = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sedum"
-version = "0.2.49"
+version = "0.2.50"
 edition = "2018"
 license = "MPL-2.0"
 description = "Sedum is a static website generator."
@@ -12,7 +12,7 @@ categories = ["web-programming"]
 
 [dependencies]
 walkdir = "2.3.2"
-extract-frontmatter = "2.1.0"
+extract-frontmatter = "4.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 pulldown-cmark = "0.8.0"

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -5,6 +5,7 @@ use std::{
     time::SystemTime,
 };
 
+use extract_frontmatter::config::{Modifier, Splitter};
 use extract_frontmatter::Extractor;
 use pulldown_cmark::{html, Parser};
 use structopt::StructOpt;
@@ -71,13 +72,13 @@ pub fn generate_html(source_file: &Path, constants: &Constants) {
             return;
         }
     };
-    let mut extractor = Extractor::new(&source_contents);
-    extractor.select_by_terminator("---");
-    extractor.strip_prefix("---");
-    let settings_yaml: String = extractor.extract();
+
+    let (settings_yaml, markdown_content) = Extractor::new(Splitter::DelimiterLine("---"))
+        .with_modifier(Modifier::StripFirstLine)
+        .extract(&source_contents);
 
     let (content, settings) = match serde_yaml::from_str(&settings_yaml) {
-        Ok(settings) => (extractor.remove().trim(), settings),
+        Ok(settings) => (markdown_content.trim(), settings),
         Err(_) => (
             source_contents.as_str(),
             Page {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -5,8 +5,7 @@ use std::{
     time::SystemTime,
 };
 
-use extract_frontmatter::config::{Modifier, Splitter};
-use extract_frontmatter::Extractor;
+use extract_frontmatter::{config::Splitter, Extractor};
 use pulldown_cmark::{html, Parser};
 use structopt::StructOpt;
 
@@ -73,9 +72,8 @@ pub fn generate_html(source_file: &Path, constants: &Constants) {
         }
     };
 
-    let (settings_yaml, markdown_content) = Extractor::new(Splitter::DelimiterLine("---"))
-        .with_modifier(Modifier::StripFirstLine)
-        .extract(&source_contents);
+    let (settings_yaml, markdown_content) =
+        Extractor::new(Splitter::EnclosingLines("---")).extract(&source_contents);
 
     let (content, settings) = match serde_yaml::from_str(&settings_yaml) {
         Ok(settings) => (markdown_content.trim(), settings),

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,4 @@
-use extract_frontmatter::config::{Modifier, Splitter};
-use extract_frontmatter::Extractor;
+use extract_frontmatter::{config::Splitter, Extractor};
 use std::{ffi::OsStr, fs, path::PathBuf};
 use structopt::StructOpt;
 use walkdir::WalkDir;
@@ -48,9 +47,8 @@ pub fn list_files(source_files: &[PathBuf]) -> (String, i64) {
             }
         };
 
-        let (settings_yaml, _) = Extractor::new(Splitter::DelimiterLine("---"))
-            .with_modifier(Modifier::StripFirstLine)
-            .extract(&source_contents);
+        let (settings_yaml, _) =
+            Extractor::new(Splitter::EnclosingLines("---")).extract(&source_contents);
 
         let settings = match serde_yaml::from_str(&settings_yaml) {
             Ok(settings) => (settings),

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,4 @@
+use extract_frontmatter::config::{Modifier, Splitter};
 use extract_frontmatter::Extractor;
 use std::{ffi::OsStr, fs, path::PathBuf};
 use structopt::StructOpt;
@@ -46,10 +47,11 @@ pub fn list_files(source_files: &[PathBuf]) -> (String, i64) {
                 continue;
             }
         };
-        let mut extractor = Extractor::new(&source_contents);
-        extractor.select_by_terminator("---");
-        extractor.strip_prefix("---");
-        let settings_yaml: String = extractor.extract();
+
+        let (settings_yaml, _) = Extractor::new(Splitter::DelimiterLine("---"))
+            .with_modifier(Modifier::StripFirstLine)
+            .extract(&source_contents);
+
         let settings = match serde_yaml::from_str(&settings_yaml) {
             Ok(settings) => (settings),
             Err(_) => Page {


### PR DESCRIPTION
I'm getting back into doing a bit of Rust dev, and on a bit of a whim, I decided to rewrite `extract-frontmatter` (I wasn't the happiest with it to begin with).

Given it was a bit arbitrary (and there's not too many consuming crates at the moment), I figured I'd do a PR that updates it for Sedum.

Kinda glad I did, as I did discover that I had inadvertantly removed buggy/quirky behaviour that you were relying on before. 🙂 Now there's something proper in place to support front-matter with a delimiter before it as well as after it.

I tested this by running it locally against the website under the `web` branch. Looks like the front-matter is correctly being picked up and put into the `<head>`.