### PR TITLE
Revert "Update extract-frontmatter from v2.1.0 to v4.1.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "82f36e03049327b02edc7e8224b54cc20cde398e46e99e3f0cc032ff315e9301"
 
 [[package]]
 name = "extract-frontmatter"
-version = "4.1.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ed88b524528147d3055c70746165356731a9a688c5ea3260d39a156e6a03ae"
+checksum = "30b4c6ac125f7d6663c9bee567645050c9a164c4dbf5689bd5bdf344a1b39356"
 
 [[package]]
 name = "getopts"
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "sedum"
-version = "0.2.50"
+version = "0.2.49"
 dependencies = [
  "epoch-converter",
  "extract-frontmatter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sedum"
-version = "0.2.50"
+version = "0.2.49"
 edition = "2018"
 license = "MPL-2.0"
 description = "Sedum is a static website generator."
@@ -12,7 +12,7 @@ categories = ["web-programming"]
 
 [dependencies]
 walkdir = "2.3.2"
-extract-frontmatter = "4.1.0"
+extract-frontmatter = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 pulldown-cmark = "0.8.0"

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -5,7 +5,7 @@ use std::{
     time::SystemTime,
 };
 
-use extract_frontmatter::{config::Splitter, Extractor};
+use extract_frontmatter::Extractor;
 use pulldown_cmark::{html, Parser};
 use structopt::StructOpt;
 
@@ -71,12 +71,13 @@ pub fn generate_html(source_file: &Path, constants: &Constants) {
             return;
         }
     };
-
-    let (settings_yaml, markdown_content) =
-        Extractor::new(Splitter::EnclosingLines("---")).extract(&source_contents);
+    let mut extractor = Extractor::new(&source_contents);
+    extractor.select_by_terminator("---");
+    extractor.strip_prefix("---");
+    let settings_yaml: String = extractor.extract();
 
     let (content, settings) = match serde_yaml::from_str(&settings_yaml) {
-        Ok(settings) => (markdown_content.trim(), settings),
+        Ok(settings) => (extractor.remove().trim(), settings),
         Err(_) => (
             source_contents.as_str(),
             Page {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use extract_frontmatter::{config::Splitter, Extractor};
+use extract_frontmatter::Extractor;
 use std::{ffi::OsStr, fs, path::PathBuf};
 use structopt::StructOpt;
 use walkdir::WalkDir;
@@ -46,10 +46,10 @@ pub fn list_files(source_files: &[PathBuf]) -> (String, i64) {
                 continue;
             }
         };
-
-        let (settings_yaml, _) =
-            Extractor::new(Splitter::EnclosingLines("---")).extract(&source_contents);
-
+        let mut extractor = Extractor::new(&source_contents);
+        extractor.select_by_terminator("---");
+        extractor.strip_prefix("---");
+        let settings_yaml: String = extractor.extract();
         let settings = match serde_yaml::from_str(&settings_yaml) {
             Ok(settings) => (settings),
             Err(_) => Page {


### PR DESCRIPTION
Reverts ellygaytor/Sedum#10. A build error occurs when compiling `extract-frontmatter`:

```
error: there is no argument named `suffix`
  --> extract-frontmatter-4.1.0/src/extraction.rs:77:33
   |
77 |     meta.strip_suffix(&format!("{suffix}\r\n")).unwrap_or_else(|| {
   |                                 ^^^^^^^^

error: there is no argument named `suffix`
  -->  extract-frontmatter-4.1.0/src/extraction.rs:78:37
   |
78 |         meta.strip_suffix(&format!("{suffix}\n")).unwrap_or_else(|| meta.strip_suffix(suffix).unwrap_or(meta))
   |                                     ^^^^^^^^

error: there is no argument named `prefix`
  -->  extract-frontmatter-4.1.0/src/extraction.rs:83:33
   |
83 |     meta.strip_prefix(&format!("{prefix}\r\n")).unwrap_or_else(|| {
   |                                 ^^^^^^^^

error: there is no argument named `prefix`
  -->  extract-frontmatter-4.1.0/src/extraction.rs:84:37
   |
84 |         meta.strip_prefix(&format!("{prefix}\n")).unwrap_or_else(|| meta.strip_prefix(prefix).unwrap_or(meta))
   |                                     ^^^^^^^^

error: could not compile `extract-frontmatter` due to 4 previous errors
```